### PR TITLE
fixed slider that modulates animation speed

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -12,6 +12,7 @@ let animatebutton
 
 let h = 0
 let speed = .1
+let animateForward = true;
 
 function preload() {
   for (let i = 0; i <= 2; i++) {
@@ -58,22 +59,17 @@ function draw() {
   background(125);
   background(200);
   speed = cubeXRotateSpeed.value()
-console.log("h:"+h+" spd:"+speed);
 
-  // problem is the next line...
-  // the variable "animating" is  never true...
-  // it's set to false at the start of the sketch
-  // and never changed anywhere.
-  // come back over...
-    if (animating) {
+  if (animating) {
+    if (animateForward) { 
       h += speed;
-      cubeRotateXSlider.value(h);
-      if (h >= 50|| h <= 0) {
-        speed *= -1;
-      }
+      if (h > 50) animateForward = false;
+    } else {
+      h -= speed;
+      if (h < 0) animateForward = true;
     }
-
-
+    cubeRotateXSlider.value(h);
+  }    
 
 
   /* to toggle a boolean back and forth. ...


### PR DESCRIPTION
We can look at this together tomorrow, but basically the way I fixed it is to use a boolean variable to keep track of whether it's animating forward or backwards and change the value of that boolean when it hits the upper or lower limit of the slider. If you remember, this is how I first showed the bouncing ball -type animation in class. Later I revised it to use the shortcut of simply multiplying speed times -1 when it hit the upper or lower limit. That can't work in your case because the speed variable isn't really under your control... you were getting the speed value from the slider every frame - so whatever changes you made to it (making it positive/negative) were getting lost when it got to the next frame (and got the speed value from the slider again). 

Look at the difference between the two files before merging this pull request. Sometimes if you choose "Split" instead of "Unified" it's easier to see what changes were made from one version (yours) to the other (my fork). Red means lines were deleted, green means those lines were added.